### PR TITLE
Added new view, url path, and template

### DIFF
--- a/project/accounts/templates/accounts/profile_following.html
+++ b/project/accounts/templates/accounts/profile_following.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block content %}
+  <div class="following-total">
+    <div>
+      {% blocktranslate %}
+        {{ profile.following.count }} following
+      {% endblocktranslate %}
+    </div>
+  </div>
+  <div class="following-list">
+    {% for following in profile.following.all %}
+    <p>{{ following.user.username }}</p>
+    {% empty %}
+        <p>{% translate "Not following any users" %}</p>
+    {% endfor %}
+  </div>
+{% endblock content %}

--- a/project/accounts/tests/test_views.py
+++ b/project/accounts/tests/test_views.py
@@ -215,3 +215,34 @@ class UserProfileView(BaseTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, self.user.username)
         self.assertTemplateUsed(response, "account.html")
+
+
+class ProfileFollowing(BaseTestCase):
+    """A class to test user profiles following view"""
+
+    def setUp(self) -> None:
+        super(ProfileFollowing, self).setUp()
+        self.user.profile.first_name = "First"
+        self.user.profile.last_name = "Last"
+        self.user.profile.about_me = "About"
+        self.user.profile.save()
+
+        self.user2 = get_user_model().objects.create_user(
+            username="newuser2", email="test@test.com", password="password123"
+        )
+        self.user3 = get_user_model().objects.create_user(
+            username="newuser3", email="test@test.com", password="password123"
+        )
+
+        self.user.profile.following.add(self.user2.profile)
+        self.user.profile.following.add(self.user3.profile)
+
+    def test_get_user_profile(self):
+        """Whether user_profile function works as expected"""
+
+        self.client.login(username="newuser", password="password123")
+        response = self.client.get(reverse("profile-following", args=["newuser"]))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, self.user2.username)
+        self.assertContains(response, self.user3.username)
+        self.assertTemplateUsed(response, "profile_following.html")

--- a/project/accounts/urls.py
+++ b/project/accounts/urls.py
@@ -5,6 +5,7 @@ from accounts.views import (
     PasswordResetView,
     ProfileActivationView,
     ProfileFollow,
+    ProfileFollowing,
     ProfileUnfollow,
     RegisterView,
     SettingsView,
@@ -29,6 +30,11 @@ urlpatterns = [
         name="accounts_activate",
     ),
     path("profile/<str:username>/", UserProfileView.as_view(), name="profile"),
+    path(
+        "profile/<str:username>/following",
+        ProfileFollowing.as_view(),
+        name="profile-following",
+    ),
     path(
         "profile/<str:username>/follow", ProfileFollow.as_view(), name="profile-follow"
     ),

--- a/project/accounts/views.py
+++ b/project/accounts/views.py
@@ -188,6 +188,21 @@ class UserProfileView(LoginRequiredMixin, View):
         )
 
 
+class ProfileFollowing(LoginRequiredMixin, View):
+    """A view that shows profiles followed for authorized users"""
+
+    def get(self, request, username=None):
+        profile = get_object_or_404(Profile, user__username=username)
+
+        return TemplateResponse(
+            request,
+            "profile_following.html",
+            {
+                "profile": profile,
+            },
+        )
+
+
 @login_required
 def expunge_user(request):
     """


### PR DESCRIPTION
## Description

We have added a new view "ProfileFollowing" that showcases a list of all profiles followed by the current user. This includes a URL path that connects our new view with a template that displays the listed profiles.

Our commit also includes unit tests that verify that users who are followed by the current user are included in the HTML page.